### PR TITLE
Target name "test" is reserved for older cmake version

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required (VERSION 3.0)
 
-add_executable(test test.cpp)
+add_executable(test_vki test.cpp)
 
-target_link_libraries(test VkInline)
+target_link_libraries(test_vki VkInline)
 
-install(TARGETS test RUNTIME DESTINATION test_cpp)
+install(TARGETS test_vki RUNTIME DESTINATION test_cpp)
 


### PR DESCRIPTION
At least cmake 3.10.2 claims "test" is reserved or not valid.

This PR fixes it(simply rename the target)

```
CMake Error at test/CMakeLists.txt:3 (add_executable):
  The target name "test" is reserved or not valid for certain CMake features,
  such as generator expressions, and may result in undefined behavior.


CMake Error at test/CMakeLists.txt:5 (target_link_libraries):
  Cannot specify link libraries for target "test" which is not built by this
  project.
```